### PR TITLE
用户当前版本版本与最新版本之间存在强制更新版本，则该次升级即为强制更新

### DIFF
--- a/modules/app-version-rest/src/main/java/com/tairanchina/csp/avm/service/impl/AndroidVersionServiceImpl.java
+++ b/modules/app-version-rest/src/main/java/com/tairanchina/csp/avm/service/impl/AndroidVersionServiceImpl.java
@@ -80,10 +80,6 @@ public class AndroidVersionServiceImpl implements AndroidVersionService {
                 String androidVersionMin = a.getAppVersion();
                 if (VersionCompareUtils.compareVersion(version, androidVersionMin) >= 0) {
                     androidVersionsResult.remove(a);
-                } else {
-                    if(a.getUpdateType().equals(0)) {
-                        forceUpdate.set(true);
-                    }
                 }
             }
         }

--- a/modules/app-version-rest/src/main/java/com/tairanchina/csp/avm/service/impl/AndroidVersionServiceImpl.java
+++ b/modules/app-version-rest/src/main/java/com/tairanchina/csp/avm/service/impl/AndroidVersionServiceImpl.java
@@ -29,6 +29,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * Created by hzlizx on 2018/6/21 0021
@@ -70,6 +71,8 @@ public class AndroidVersionServiceImpl implements AndroidVersionService {
         }
         // 将查询结果再次进行筛选，选出大于传入version的安卓版本，然后再找出最新版本
         List<AndroidVersion> androidVersionsResult = new LinkedList<>();
+        //是否强制更新
+        AtomicBoolean forceUpdate = new AtomicBoolean(false);
         androidVersionsResult.addAll(androidVersions);
         if (VersionCompareUtils.compareVersion(version, androidVersions.get(androidVersions.size() - 1).getAppVersion()) > 0) {
             Collections.reverse(androidVersions);
@@ -77,6 +80,10 @@ public class AndroidVersionServiceImpl implements AndroidVersionService {
                 String androidVersionMin = a.getAppVersion();
                 if (VersionCompareUtils.compareVersion(version, androidVersionMin) >= 0) {
                     androidVersionsResult.remove(a);
+                } else {
+                    if(a.getUpdateType().equals(0)) {
+                        forceUpdate.set(true);
+                    }
                 }
             }
         }
@@ -86,7 +93,11 @@ public class AndroidVersionServiceImpl implements AndroidVersionService {
         }
         logger.debug("查询到的筛选过的版本：");
         androidVersionsResult.forEach(androidVersion -> logger.debug(androidVersion.getAppVersion()));
-
+        androidVersionsResult.forEach(androidVersion -> {
+            if (androidVersion.getUpdateType().equals(0)) {
+                forceUpdate.set(true);
+            }
+        });
         //查找指定渠道
         logger.debug("查询channelCode为{}的渠道...", channelCode);
         Channel channel = new Channel();
@@ -117,7 +128,7 @@ public class AndroidVersionServiceImpl implements AndroidVersionService {
         for (AndroidVersion androidVersion : androidVersionsResult) {
             if (channelSelected != null) {
                 if (channelSelected.getChannelStatus() == 1) {
-                    HashMap<String, Object> apk = this.findApk(androidVersion, appSelected.getId(), channelSelected.getId());
+                    HashMap<String, Object> apk = this.findApk(androidVersion, appSelected.getId(), channelSelected.getId(), forceUpdate.get());
                     if (apk != null) {
                         logger.debug("结果：{}", $.json.toJsonString(apk));
                         return ServiceResult.ok(apk);
@@ -125,7 +136,7 @@ public class AndroidVersionServiceImpl implements AndroidVersionService {
                 }
             }
             if (officialChannel != null) {
-                HashMap<String, Object> apk = this.findApk(androidVersion, appSelected.getId(), officialChannel.getId());
+                HashMap<String, Object> apk = this.findApk(androidVersion, appSelected.getId(), officialChannel.getId(), forceUpdate.get());
                 if (apk != null) {
                     logger.debug("结果：{}", $.json.toJsonString(apk));
                     return ServiceResult.ok(apk);
@@ -234,7 +245,7 @@ public class AndroidVersionServiceImpl implements AndroidVersionService {
         return null;
     }
 
-    private HashMap<String, Object> findApk(AndroidVersion androidVersion, int appId, int channelId) {
+    private HashMap<String, Object> findApk(AndroidVersion androidVersion, int appId, int channelId, boolean forceUpdate) {
         int versionId = androidVersion.getId();
         Apk apk = new Apk();
         apk.setAppId(appId);
@@ -250,7 +261,7 @@ public class AndroidVersionServiceImpl implements AndroidVersionService {
             map.put("allowLowestVersion", androidVersion.getAllowLowestVersion());
             map.put("downloadUrl", "/v/download/" + apkSelected.getId());
             map.put("description", androidVersion.getVersionDescription());
-            map.put("forceUpdate", androidVersion.getUpdateType());
+            map.put("forceUpdate", forceUpdate ? 0 : androidVersion.getUpdateType());
             map.put("version", androidVersion.getAppVersion());
             return map;
         }

--- a/modules/app-version-rest/src/main/java/com/tairanchina/csp/avm/service/impl/IosVersionServiceImpl.java
+++ b/modules/app-version-rest/src/main/java/com/tairanchina/csp/avm/service/impl/IosVersionServiceImpl.java
@@ -19,6 +19,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * Created by hzlizx on 2018/6/21 0021
@@ -54,6 +55,8 @@ public class IosVersionServiceImpl implements IosVersionService {
         }
         // 将查询结果再次进行筛选，选出大于传入version的版本，然后再找出最新版本
         List<IosVersion> iosVersionsResult = new LinkedList<>();
+        //是否强制更新
+        AtomicBoolean forceUpdate = new AtomicBoolean(false);
         iosVersionsResult.addAll(iosVersions);
         iosVersions.forEach(iosVersion -> logger.debug(iosVersion.getAppVersion()));
         if (VersionCompareUtils.compareVersion(version, iosVersions.get(iosVersions.size() - 1).getAppVersion()) > 0) {
@@ -71,7 +74,11 @@ public class IosVersionServiceImpl implements IosVersionService {
         }
         logger.debug("查询到的版本：");
         iosVersionsResult.forEach(iosVersion -> logger.debug(iosVersion.getAppVersion()));
-
+        iosVersionsResult.forEach(iosVersion -> {
+            if(iosVersion.getUpdateType().equals(0)) {
+                forceUpdate.set(true);
+            }
+        });
         IosVersion iosVersion = iosVersionsResult.get(0);
         logger.debug("当前最新版本为：{}", iosVersion.getAppVersion());
 
@@ -80,7 +87,7 @@ public class IosVersionServiceImpl implements IosVersionService {
         map.put("allowLowestVersion", iosVersion.getAllowLowestVersion());
         map.put("appStoreUrl", iosVersion.getAppStoreUrl());
         map.put("description", iosVersion.getVersionDescription());
-        map.put("forceUpdate", iosVersion.getUpdateType());
+        map.put("forceUpdate", forceUpdate.get() ? 0 : iosVersion.getUpdateType());
         map.put("version", iosVersion.getAppVersion());
         ServiceResult ok = ServiceResult.ok(map);
         logger.debug("结果：{}", $.json.toJsonString(ok));


### PR DESCRIPTION
- 举个例子：

用户当前版本| 版本 | 是否强制更新
---|---|---
1.0.0.0 | 1.0.0.0 | 否
1.0.0.0 | 1.0.0.1 | 是
1.0.0.0 | 1.0.0.2 | 否

#### 用户当前使用版本为1.0.0.0版本，1.0.0.1版本强制更新，1.0.0.2版本非强制升级，在1.0.0.1到1.0.0.2期间，用户未启动App，当用户再次使用App时，当前最新版本为1.0.0.2，版本检查为非强制更新，这样的场景，就影响了用户的正常使用，因为用户错过了1.1的强制更新，极有可能影响接口正常使用。


#### 看了一下您的做法是让app端通过这个版本号 allowLowestVersion（允许最低版本（低于这个要强制更新）） 来判断是否需要强制更新。